### PR TITLE
'vpc' attribute in aws_eip resource was deprecated in newer AWS Provi…

### DIFF
--- a/terraform/bigip-vips.tf
+++ b/terraform/bigip-vips.tf
@@ -1,7 +1,7 @@
 ### Elastic (Public) IP Address Assignments for Virtual Servers
 
 resource "aws_eip" "vip1" {
-  vpc                       = true
+  domain                    = "vpc"
   network_interface         = aws_network_interface.bigip1_external.id
   associate_with_private_ip = var.bigip_netcfg["bigip1"]["app_vips"][0]
 

--- a/terraform/bigip1.tf
+++ b/terraform/bigip1.tf
@@ -132,7 +132,7 @@ resource "aws_network_interface" "bigip1_internal" {
 
 # Public IP Address for management IP (jumphost inbound access)
 resource "aws_eip" "bigip1_mgmt" {
-  vpc               = true
+  domain            = "vpc"
   network_interface = aws_network_interface.bigip1_mgmt.id
 
   tags = {

--- a/terraform/bigip2.tf
+++ b/terraform/bigip2.tf
@@ -132,7 +132,7 @@ resource "aws_network_interface" "bigip2_internal" {
 
 # Public IP Address for management IP (jumphost inbound access)
 resource "aws_eip" "bigip2_mgmt" {
-  vpc               = true
+  domain            = "vpc"
   network_interface = aws_network_interface.bigip2_mgmt.id
 
   tags = {

--- a/terraform/nat-gateway.tf
+++ b/terraform/nat-gateway.tf
@@ -1,7 +1,7 @@
 # NAT Gateway for outbound Internet access from private IPs
 
 resource "aws_eip" "hub_ngw" {
-  vpc = true
+  domain = "vpc"
 }
 
 # Note: NAT Gateway deployed into a single AZ to simplify this lab. Recommended practice is to


### PR DESCRIPTION
…der, so replaced with 'domain' attribute.